### PR TITLE
Remove use strict, not needed with ES6 modules

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import 'babel-polyfill';
 import './dependencies';
 

--- a/src/common/services/user.js
+++ b/src/common/services/user.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import 'isomorphic-fetch';
 import {ENVIRONMENT} from '../constants/environment';
 import {USER} from '../constants/endpoints';

--- a/src/components/Avatar.js
+++ b/src/components/Avatar.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import React, {Component} from 'react';
 
 export default class Avatar extends Component {

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import React, {Component} from 'react';
 
 export default class Header extends Component {

--- a/src/components/LeftNavigation.js
+++ b/src/components/LeftNavigation.js
@@ -1,4 +1,3 @@
-'use strict';
 import React, {Component} from 'react';
 import Avatar from './Avatar';
 import NavigationMenu from './NavigationMenu';

--- a/src/components/NavigationMenu.js
+++ b/src/components/NavigationMenu.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import React, {Component} from 'react';
 
 export default class NavigationMenu extends Component {

--- a/src/containers/Dashboard/DashboardContent/index.js
+++ b/src/containers/Dashboard/DashboardContent/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import React, {Component} from 'react';
 
 export default class DashboardContent extends Component {

--- a/src/containers/Dashboard/index.js
+++ b/src/containers/Dashboard/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import React, {Component, PropTypes} from 'react';
 import {connect} from 'react-redux';
 import {hashHistory} from 'react-router';

--- a/src/containers/StartScreen/Login/Loading/index.js
+++ b/src/containers/StartScreen/Login/Loading/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import React, {Component} from 'react';
 import classNames from 'classnames';
 

--- a/src/containers/StartScreen/Login/index.js
+++ b/src/containers/StartScreen/Login/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import React, {Component} from 'react';
 import Loading from './Loading';
 


### PR DESCRIPTION
When you use ES6 modules, you're already using strict mode. Not sure what the intention was here... If you were trying to do a more ES5 style and stuck solely to require() calls, then it would make sense to want to declare strict mode.
